### PR TITLE
Add go build ci workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.18', '1.19', '1.20' ]
+        go-version: ['1.20']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,25 @@
+name: Go
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.18', '1.19', '1.20' ]
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      
+      - name: Build Go Project
+        run: make build
+
+      - name: Smoke Test
+        run: ./eksdemo version


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a CI workflow which builds eksdemo against Go versions (1.18, 1.19 and 1.20) and runs a smoke test (eksdemo version)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
