### PR TITLE
Fix uninstall command for kubecost

### DIFF
--- a/cmd/install/kubecost.go
+++ b/cmd/install/kubecost.go
@@ -35,7 +35,7 @@ func NewUninstallKubecostCmd() *cobra.Command {
 	// Don't show flag errors for `uninstall kubecost` without a subcommand
 	cmd.DisableFlagParsing = true
 
-	for _, a := range fluxApps {
+	for _, a := range kubecostApps {
 		cmd.AddCommand(a().NewUninstallCmd())
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Kubecost uninstall had a bug. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
