### PR TITLE
update: `kube-prometheus-stack` to chart 46.6.0

### DIFF
--- a/pkg/application/kube_prometheus/kube_prometheus_stack/kube_prometheus_stack.go
+++ b/pkg/application/kube_prometheus/kube_prometheus_stack/kube_prometheus_stack.go
@@ -12,7 +12,7 @@ import (
 // Helm:    https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack
 // Helm:    https://github.com/grafana/helm-charts/tree/main/charts/grafana
 // Repo:    https://quay.io/prometheus-operator/prometheus-operator
-// Version: Latest is Chart 45.1.1, PromOperator v0.63.0 (as of 2/18/23)
+// Version: Latest is Chart 46.6.0, PromOperator v0.65.1 (as of 6/2/23)
 //          But pinning Previous Chart to 34.10.0 due to breaking API Server graphs for k8s < 1.23
 //          https://github.com/prometheus-community/helm-charts/issues/2018
 

--- a/pkg/application/kube_prometheus/kube_prometheus_stack/options.go
+++ b/pkg/application/kube_prometheus/kube_prometheus_stack/options.go
@@ -14,8 +14,8 @@ func newOptions() (options *KubePrometheusStackOptions, flags cmd.Flags) {
 	options = &KubePrometheusStackOptions{
 		ApplicationOptions: &application.ApplicationOptions{
 			DefaultVersion: &application.LatestPrevious{
-				LatestChart:   "45.1.1",
-				Latest:        "v0.63.0",
+				LatestChart:   "46.6.0",
+				Latest:        "v0.65.1",
 				PreviousChart: "34.10.0",
 				Previous:      "v0.55.0",
 			},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update `kube-prometheus-stack` to chart 46.6.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
