### PR TITLE
update: `cluster create` defaults to use resource name hostnames

### DIFF
--- a/pkg/resource/cluster/options.go
+++ b/pkg/resource/cluster/options.go
@@ -51,7 +51,7 @@ func addOptions(res *resource.Resource) *resource.Resource {
 			KubernetesVersion:   "1.27",
 		},
 
-		HostnameType:     string(types.HostnameTypeIpName),
+		HostnameType:     string(types.HostnameTypeResourceName),
 		NodegroupOptions: ngOptions,
 		NoRoles:          false,
 		VpcCidr:          "192.168.0.0/16",


### PR DESCRIPTION
*Issue #, if available:*
#31 

*Description of changes:*
Update: `cluster create` defaults to use resource name hostnames

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
