### PR TITLE
update: `create nodegroup` adds taint for GPU and Neuron nodes

### DIFF
--- a/pkg/resource/nodegroup/nodegroup.go
+++ b/pkg/resource/nodegroup/nodegroup.go
@@ -64,4 +64,10 @@ managedNodeGroups:
 {{- end }}
   privateNetworking: true
   spot: {{ .Spot }}
+{{- range .Taints }}
+  taints:
+  - key: {{ .Key }}
+    value: {{ .Value | printf "%q" }}
+    effect: {{ .Effect }}
+{{- end }}
 `


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`create nodegroup` adds taint for GPU and Neuron nodes

Also includes `--no-taints` flag if you don't want the taint

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
