### PR TITLE
Add core-dump-handler

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/eksdemo/pkg/application/aws_lb_controller"
 	"github.com/awslabs/eksdemo/pkg/application/cert_manager"
 	"github.com/awslabs/eksdemo/pkg/application/cilium"
+	"github.com/awslabs/eksdemo/pkg/application/coredumphandler"
 	"github.com/awslabs/eksdemo/pkg/application/crossplane"
 	"github.com/awslabs/eksdemo/pkg/application/external_dns"
 	"github.com/awslabs/eksdemo/pkg/application/falco"
@@ -51,6 +52,7 @@ func NewInstallCmd() *cobra.Command {
 	cmd.AddCommand(aws_lb_controller.NewApp().NewInstallCmd())
 	cmd.AddCommand(cert_manager.NewApp().NewInstallCmd())
 	cmd.AddCommand(cilium.NewApp().NewInstallCmd())
+	cmd.AddCommand(coredumphandler.NewApp().NewInstallCmd())
 	cmd.AddCommand(NewInstallContainerInsightsCmd())
 	cmd.AddCommand(NewInstallAliasCmds(containerInsightsApps, "container-insights-")...)
 	cmd.AddCommand(NewInstallAliasCmds(containerInsightsApps, "ci-")...)

--- a/cmd/install/uninstall.go
+++ b/cmd/install/uninstall.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/eksdemo/pkg/application/aws_lb_controller"
 	"github.com/awslabs/eksdemo/pkg/application/cert_manager"
 	"github.com/awslabs/eksdemo/pkg/application/cilium"
+	"github.com/awslabs/eksdemo/pkg/application/coredumphandler"
 	"github.com/awslabs/eksdemo/pkg/application/crossplane"
 	"github.com/awslabs/eksdemo/pkg/application/external_dns"
 	"github.com/awslabs/eksdemo/pkg/application/falco"
@@ -51,6 +52,7 @@ func NewUninstallCmd() *cobra.Command {
 	cmd.AddCommand(aws_lb_controller.NewApp().NewUninstallCmd())
 	cmd.AddCommand(cert_manager.NewApp().NewUninstallCmd())
 	cmd.AddCommand(cilium.NewApp().NewUninstallCmd())
+	cmd.AddCommand(coredumphandler.NewApp().NewUninstallCmd())
 	cmd.AddCommand(NewUninstallContainerInsightsCmd())
 	cmd.AddCommand(NewUninstallAliasCmds(containerInsightsApps, "container-insights-")...)
 	cmd.AddCommand(NewUninstallAliasCmds(containerInsightsApps, "ci-")...)

--- a/pkg/application/coredumphandler/coredumphandler.go
+++ b/pkg/application/coredumphandler/coredumphandler.go
@@ -1,0 +1,83 @@
+package coredumphandler
+
+import (
+	"github.com/awslabs/eksdemo/pkg/application"
+	"github.com/awslabs/eksdemo/pkg/cmd"
+	"github.com/awslabs/eksdemo/pkg/installer"
+	"github.com/awslabs/eksdemo/pkg/resource"
+	"github.com/awslabs/eksdemo/pkg/resource/irsa"
+	"github.com/awslabs/eksdemo/pkg/resource/s3_bucket"
+	"github.com/awslabs/eksdemo/pkg/template"
+)
+
+// Docs:    https://github.com/IBM/core-dump-handler
+// Helm:    https://ibm.github.io/core-dump-handler/
+// Values:  https://github.com/IBM/core-dump-handler/blob/main/charts/core-dump-handler/values.aws.sts.yaml
+// Repo:    https://quay.io/repository/icdh/core-dump-handler
+// Version: Latest is Chart/App v8.10.0 (as of 10/24/23)
+
+func NewApp() *application.Application {
+	options, flags := newOptions()
+
+	app := &application.Application{
+		Command: cmd.Command{
+			Name:        "core-dump-handler",
+			Description: "Automatically saves core dumps to S3",
+		},
+
+		Dependencies: []*resource.Resource{
+			irsa.NewResourceWithOptions(&irsa.IrsaOptions{
+				CommonOptions: resource.CommonOptions{
+					Name: "core-dump-handler-irsa",
+				},
+				PolicyType: irsa.PolicyDocument,
+				PolicyDocTemplate: &template.TextTemplate{
+					Template: policyDocument,
+				},
+			}),
+			s3_bucket.NewResourceWithOptions(options.BucketOptions),
+		},
+
+		Flags: flags,
+
+		Installer: &installer.HelmInstaller{
+			ChartName:     "core-dump-handler",
+			ReleaseName:   "core-dump-handler",
+			RepositoryURL: "https://ibm.github.io/core-dump-handler/",
+			ValuesTemplate: &template.TextTemplate{
+				Template: valuesTemplate,
+			},
+		},
+
+		Options: options,
+	}
+
+	return app
+}
+
+const valuesTemplate = `---
+# https://github.com/IBM/core-dump-handler/blob/main/charts/core-dump-handler/values.aws.sts.yaml
+daemonset:
+  includeCrioExe: {{ not .IncludeCrioExe }}
+  vendor: rhel7 # EKS EC2 images have an old libc=2.26
+  s3BucketName: eksdemo-{{ .Account }}-coredumphandler
+  s3Region: {{ .Region }}
+
+serviceAccount:
+  name: {{ .ServiceAccount }}
+  annotations:
+    {{ .IrsaAnnotation }}
+`
+
+// https://github.com/IBM/core-dump-handler/blob/main/charts/core-dump-handler/README.md#eks-setup-for-gitops-pipelines-eksctl-or-similar
+const policyDocument = `
+Version: '2012-10-17'
+Statement:
+- Effect: Allow
+  Action:
+  - s3:*
+  Resource: [
+   "arn:{{ .Partition }}:s3:::eksdemo-{{ .Account }}-coredumphandler",
+   "arn:{{ .Partition }}:s3:::eksdemo-{{ .Account }}-coredumphandler/*"
+  ]
+`

--- a/pkg/application/coredumphandler/options.go
+++ b/pkg/application/coredumphandler/options.go
@@ -1,0 +1,52 @@
+package coredumphandler
+
+import (
+	"fmt"
+
+	"github.com/awslabs/eksdemo/pkg/application"
+	"github.com/awslabs/eksdemo/pkg/cmd"
+	"github.com/awslabs/eksdemo/pkg/resource"
+	"github.com/awslabs/eksdemo/pkg/resource/s3_bucket"
+)
+
+type Options struct {
+	application.ApplicationOptions
+
+	*s3_bucket.BucketOptions
+	IncludeCrioExe bool
+}
+
+func newOptions() (options *Options, flags cmd.Flags) {
+	options = &Options{
+		ApplicationOptions: application.ApplicationOptions{
+			Namespace:      "core-dump-handler",
+			ServiceAccount: "core-dump-handler",
+			DefaultVersion: &application.LatestPrevious{
+				LatestChart:   "v8.10.0",
+				Latest:        "v8.10.0",
+				PreviousChart: "v8.10.0",
+				Previous:      "v8.10.0",
+			},
+		},
+		BucketOptions: &s3_bucket.BucketOptions{
+			CommonOptions: resource.CommonOptions{
+				Name: "coredumphandler-s3-bucket",
+			},
+		},
+	}
+	flags = cmd.Flags{
+		&cmd.BoolFlag{
+			CommandFlag: cmd.CommandFlag{
+				Name:        "dont-include-crio-exe",
+				Description: "don't include CRI-O executable",
+			},
+			Option: &options.IncludeCrioExe,
+		},
+	}
+	return
+}
+
+func (o *Options) PreDependencies(application.Action) error {
+	o.BucketOptions.BucketName = fmt.Sprintf("eksdemo-%s-coredumphandler", o.Account)
+	return nil
+}


### PR DESCRIPTION
Closes: #122 

Add [core-dump-handler](https://github.com/IBM/core-dump-handler) application that send coredump of binaries into a S3 bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
