### PR TITLE
fix: disable AMI lookup for fully private clusters

### DIFF
--- a/pkg/resource/cluster/options.go
+++ b/pkg/resource/cluster/options.go
@@ -179,6 +179,8 @@ func (o *ClusterOptions) PreCreate() error {
 	o.Account = aws.AccountId()
 	o.Partition = aws.Partition()
 	o.Region = aws.Region()
+
+	o.NodegroupOptions.IsClusterPrivate = o.Private
 	o.NodegroupOptions.KubernetesVersion = o.KubernetesVersion
 
 	// For apps we want to pre-create IRSA for, find the IRSA dependency

--- a/pkg/resource/nodegroup/options.go
+++ b/pkg/resource/nodegroup/options.go
@@ -24,18 +24,19 @@ const eksOptmizedGpuAmiPath = "/aws/service/eks/optimized-ami/%s/amazon-linux-2-
 type NodegroupOptions struct {
 	*resource.CommonOptions
 
-	AMI             string
-	InstanceType    string
-	DesiredCapacity int
-	MinSize         int
-	MaxSize         int
-	NodegroupName   string
-	NoTaints        bool
-	OperatingSystem string
-	Spot            bool
-	SpotvCPUs       int
-	SpotMemory      int
-	Taints          []Taint
+	AMI              string
+	InstanceType     string
+	IsClusterPrivate bool
+	DesiredCapacity  int
+	MinSize          int
+	MaxSize          int
+	NodegroupName    string
+	NoTaints         bool
+	OperatingSystem  string
+	Spot             bool
+	SpotvCPUs        int
+	SpotMemory       int
+	Taints           []Taint
 
 	UpdateDesired int
 	UpdateMin     int
@@ -212,8 +213,8 @@ func (o *NodegroupOptions) PreCreate() error {
 		o.Taints = append(o.Taints, Taint{Key: "nvidia.com/gpu", Effect: "NoSchedule"})
 	}
 
-	// AMI Lookup is currently only for Amazon Linux 2 EKS Optimized AMI
-	if o.OperatingSystem != "AmazonLinux2" {
+	// AMI Lookup is currently only for Amazon Linux 2 EKS Optimized AMI and clusters that aren't fully private
+	if o.OperatingSystem != "AmazonLinux2" || o.IsClusterPrivate {
 		return nil
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fix: disable AMI lookup for fully private clusters

I haven't yet found a way to support custom AMI for fully private clusters


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
