### PR TITLE
fix: delete cluster to use `--disable-nodegroup-eviction` flag

### DIFF
--- a/pkg/eksctl/manager.go
+++ b/pkg/eksctl/manager.go
@@ -25,6 +25,7 @@ type ResourceManager struct {
 	Resource       string
 	ConfigTemplate template.Template
 	CreateFlags    []string
+	DeleteFlags    []string
 	DeleteCommand  template.Template
 	ApproveCreate  bool
 	ApproveDelete  bool
@@ -97,6 +98,10 @@ func (e *ResourceManager) DeleteWithConfigFile(options resource.Options) error {
 
 	if e.ApproveDelete {
 		args = append(args, "--approve")
+	}
+
+	if len(e.DeleteFlags) > 0 {
+		args = append(args, e.DeleteFlags...)
 	}
 
 	return Command(args, eksctlConfig)

--- a/pkg/resource/cluster/cluster.go
+++ b/pkg/resource/cluster/cluster.go
@@ -24,6 +24,7 @@ func NewResource() *resource.Resource {
 			ConfigTemplate: &template.TextTemplate{
 				Template: eksctl.EksctlHeader + EksctlTemplate + nodegroup.EksctlTemplate,
 			},
+			DeleteFlags: []string{"--disable-nodegroup-eviction"},
 		},
 	}
 


### PR DESCRIPTION
*Issue #, if available:*
#138 

*Description of changes:*
use `--disable-nodegroup-eviction` flag when deleting cluster otherwise PDB can prevent node eviction and cluster won't be deleted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
