### PR TITLE
add: print eksctl command input during error for troubleshooting

### DIFF
--- a/pkg/eksctl/command.go
+++ b/pkg/eksctl/command.go
@@ -28,7 +28,15 @@ func Command(args []string, stdin string) error {
 
 	slurp, _ := io.ReadAll(stderr)
 	err := command.Wait()
+
 	if err != nil {
+		// Print out the input to eksctl with line numbers for easier troubleshooting
+		fmt.Println("\nThe following command failed:\neksctl " + strings.Join(args, " "))
+		fmt.Println("Standard input is included below with line numbers:")
+		s := bufio.NewScanner(strings.NewReader(stdin))
+		for i := 1; s.Scan(); i++ {
+			fmt.Printf("%3d: %s\n", i, s.Bytes())
+		}
 		return fmt.Errorf("eksctl failed: %s", string(slurp))
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add: print eksctl command input during error for troubleshooting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
