### PR TITLE
Expose --zones flag for eksctl cluster creation

### DIFF
--- a/pkg/resource/cluster/cluster.go
+++ b/pkg/resource/cluster/cluster.go
@@ -79,4 +79,11 @@ privateCluster:
 vpc:
   cidr: {{ .VpcCidr }}
   hostnameType: {{ .HostnameType }}
+
+{{- if .Zones }}
+availabilityZones:
+{{- range .Zones }}
+- {{.}}
+{{- end }}
+{{- end }}
 `

--- a/pkg/resource/cluster/options.go
+++ b/pkg/resource/cluster/options.go
@@ -37,6 +37,7 @@ type ClusterOptions struct {
 	PrefixAssignment     bool
 	Private              bool
 	VpcCidr              string
+	Zones                []string
 
 	appsForIrsa  []*application.Application
 	IrsaTemplate *template.TextTemplate
@@ -167,6 +168,13 @@ func addOptions(res *resource.Resource) *resource.Resource {
 				},
 			},
 			Option: &options.VpcCidr,
+		},
+		&cmd.StringSliceFlag{
+			CommandFlag: cmd.CommandFlag{
+				Name:        "zones",
+				Description: "Specify comma delimited AZs to use. ie. us-east-1a,us-east-1b,us-east-1c",
+			},
+			Option: &options.Zones,
 		},
 	}
 


### PR DESCRIPTION
*Issue #162 162*

*Description of changes:*
Adds --zones flag as a comma separated value to select zones for eksctl at cluster creation time.

I tested in us-east-1, and was able to select zones. --dry-run also shows the new availabilityZones section in the eksctltemplate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
