### PR TITLE
HashiCorp Consul application

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/eksdemo/pkg/application/aws_lb_controller"
 	"github.com/awslabs/eksdemo/pkg/application/cert_manager"
 	"github.com/awslabs/eksdemo/pkg/application/cilium"
+	"github.com/awslabs/eksdemo/pkg/application/consul"
 	"github.com/awslabs/eksdemo/pkg/application/coredumphandler"
 	"github.com/awslabs/eksdemo/pkg/application/crossplane"
 	"github.com/awslabs/eksdemo/pkg/application/external_dns"
@@ -85,6 +86,7 @@ func NewInstallCmd() *cobra.Command {
 	cmd.AddCommand(NewInstallStorageCmd())
 	cmd.AddCommand(NewInstallAliasCmds(storageApps, "storage-")...)
 	cmd.AddCommand(velero.NewApp().NewInstallCmd())
+	cmd.AddCommand(consul.NewApp().NewInstallCmd())
 
 	// Hidden commands for popular apps without using the group
 	cmd.AddCommand(NewInstallAliasCmds([]func() *application.Application{argo_cd.NewApp}, "argo")...)

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -53,10 +53,11 @@ func NewInstallCmd() *cobra.Command {
 	cmd.AddCommand(aws_lb_controller.NewApp().NewInstallCmd())
 	cmd.AddCommand(cert_manager.NewApp().NewInstallCmd())
 	cmd.AddCommand(cilium.NewApp().NewInstallCmd())
-	cmd.AddCommand(coredumphandler.NewApp().NewInstallCmd())
+	cmd.AddCommand(consul.NewApp().NewInstallCmd())
 	cmd.AddCommand(NewInstallContainerInsightsCmd())
 	cmd.AddCommand(NewInstallAliasCmds(containerInsightsApps, "container-insights-")...)
 	cmd.AddCommand(NewInstallAliasCmds(containerInsightsApps, "ci-")...)
+	cmd.AddCommand(coredumphandler.NewApp().NewInstallCmd())
 	cmd.AddCommand(crossplane.NewApp().NewInstallCmd())
 	cmd.AddCommand(NewInstallExampleCmd())
 	cmd.AddCommand(NewInstallAliasCmds(exampleApps, "example-")...)
@@ -86,7 +87,6 @@ func NewInstallCmd() *cobra.Command {
 	cmd.AddCommand(NewInstallStorageCmd())
 	cmd.AddCommand(NewInstallAliasCmds(storageApps, "storage-")...)
 	cmd.AddCommand(velero.NewApp().NewInstallCmd())
-	cmd.AddCommand(consul.NewApp().NewInstallCmd())
 
 	// Hidden commands for popular apps without using the group
 	cmd.AddCommand(NewInstallAliasCmds([]func() *application.Application{argo_cd.NewApp}, "argo")...)

--- a/cmd/install/uninstall.go
+++ b/cmd/install/uninstall.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/eksdemo/pkg/application/aws_lb_controller"
 	"github.com/awslabs/eksdemo/pkg/application/cert_manager"
 	"github.com/awslabs/eksdemo/pkg/application/cilium"
+	"github.com/awslabs/eksdemo/pkg/application/consul"
 	"github.com/awslabs/eksdemo/pkg/application/coredumphandler"
 	"github.com/awslabs/eksdemo/pkg/application/crossplane"
 	"github.com/awslabs/eksdemo/pkg/application/external_dns"
@@ -85,6 +86,7 @@ func NewUninstallCmd() *cobra.Command {
 	cmd.AddCommand(NewUninstallStorageCmd())
 	cmd.AddCommand(NewUninstallAliasCmds(storageApps, "storage-")...)
 	cmd.AddCommand(velero.NewApp().NewUninstallCmd())
+	cmd.AddCommand(consul.NewApp().NewUninstallCmd())
 
 	// Hidden commands for popular apps without using the group
 	cmd.AddCommand(NewUninstallAliasCmds([]func() *application.Application{argo_cd.NewApp}, "argo")...)

--- a/cmd/install/uninstall.go
+++ b/cmd/install/uninstall.go
@@ -53,10 +53,11 @@ func NewUninstallCmd() *cobra.Command {
 	cmd.AddCommand(aws_lb_controller.NewApp().NewUninstallCmd())
 	cmd.AddCommand(cert_manager.NewApp().NewUninstallCmd())
 	cmd.AddCommand(cilium.NewApp().NewUninstallCmd())
-	cmd.AddCommand(coredumphandler.NewApp().NewUninstallCmd())
+	cmd.AddCommand(consul.NewApp().NewUninstallCmd())
 	cmd.AddCommand(NewUninstallContainerInsightsCmd())
 	cmd.AddCommand(NewUninstallAliasCmds(containerInsightsApps, "container-insights-")...)
 	cmd.AddCommand(NewUninstallAliasCmds(containerInsightsApps, "ci-")...)
+	cmd.AddCommand(coredumphandler.NewApp().NewUninstallCmd())
 	cmd.AddCommand(crossplane.NewApp().NewUninstallCmd())
 	cmd.AddCommand(NewUninstallExampleCmd())
 	cmd.AddCommand(NewUninstallAliasCmds(exampleApps, "example-")...)
@@ -86,7 +87,6 @@ func NewUninstallCmd() *cobra.Command {
 	cmd.AddCommand(NewUninstallStorageCmd())
 	cmd.AddCommand(NewUninstallAliasCmds(storageApps, "storage-")...)
 	cmd.AddCommand(velero.NewApp().NewUninstallCmd())
-	cmd.AddCommand(consul.NewApp().NewUninstallCmd())
 
 	// Hidden commands for popular apps without using the group
 	cmd.AddCommand(NewUninstallAliasCmds([]func() *application.Application{argo_cd.NewApp}, "argo")...)

--- a/docs/install-hashicorp-consul.md
+++ b/docs/install-hashicorp-consul.md
@@ -1,0 +1,117 @@
+# Install HashiCorp Consul Application with Consul self-signed TLS
+
+`eksdemo` makes it extremely easy to install applications from it’s extensive application catalog in your EKS clusters. In this section we will walk through the installation of [HashiCorp Consul](https://www.hashicorp.com/products/consul).
+
+1. [Prerequisites](#prerequisites)
+2. [Install HashiCorp Consul](#Install-HashiCorp-Consul) — Will use optional configuration flags to specify an Ingress with TLS
+
+## Prerequisites
+
+Click on the name of the prerequisites in the list below for a link to detailed instructions.
+
+* [AWS EBS CSI Driver](/docs/install-ebs-csi-driver.md) - Consul uses stateful EBS volumes for its key/value store, so this addon is required before installation.
+* [AWS Load Balancer Controller](/docs/install-awslb.md) — Consul can expose the UI through a k8s service, which is accessed through a an AWS LoadBalancer. If you plan to use the Web UI when installing Consul, this addon is required.
+
+### Install HashiCorp Consul
+
+[HashiCorp Consul](https://www.hashicorp.com/products/consul) is a popular Service Networking/Mesh product. 
+
+In this section we will walk through the process of installing HashiCorp Consul. The command for performing the installation is **`eksdemo install consul -c <cluster-name> --namespace consul --enableUI --replicas <1 or 3>`**
+
+Let’s learn a bit more about the command and it’s options before we continue by using the `-h` help shorthand flag.
+
+```
+» eksdemo install consul -h
+Install consul
+
+Usage:
+  eksdemo install consul [flags]
+
+Flags:
+      --chart-version string     chart version (default "1.4.1")
+  -c, --cluster string           cluster to install application (required)
+      --dry-run                  don't install, just print out all installation steps
+      --enableUI                 Enable Consul UI
+  -h, --help                     help for consul
+  -n, --namespace string         namespace to install
+      --replicas int             1 or 3 replicas (default 1)
+      --service-account string   service account name
+      --set strings              set chart values (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --use-previous             use previous working chart/app versions ("1.4.0"/"v1.18.0")
+  -v, --version string           application version (default "v1.18.1")
+
+Global Flags:
+      --profile string   use the specific profile from your credential file
+      --region string    the region to use, overrides config/env settings
+```
+
+You’ll notice above there is an optional `--replicas` flag with a default of 1. If you decide to run 3 replicas, the EKS cluster you provisioned must have at least 3 nodes. Consul servers have a podAntiAffinity configured on the stateful set using `topologyKey: kubernetes.io/hostname`. 
+
+Lastly if you want to expose the Consul UI through a LoadBalancer, the `--enableUI` flag must be set. This will create an external facing NLB with cross-AZ enabled on port 443/TCP. Consul is configured to deploy using a self-signed certificate. When you access the NLB endpoint your browser will complain about the certificate, use your browser bypass method to access. ie. Type `thisisunsafe` for Chrome.
+
+If you do not expose the Consul UI through a LoadBalancer, you can port-forward to the consul-server k8s service with the following command.
+
+`kubectl port-forward service/consul-server --namespace consul 8501:8501`
+
+Manifest Installer Dry Run:
+
+```
+» eksdemo install consul -c istio-demo --enableUI --namespace consul --replicas 3 --dry-run
+
+Helm Installer Dry Run:
++---------------------+-------------------------------------+
+| Application Version | v1.18.1                             |
+| Chart Version       | 1.4.1                               |
+| Chart Repository    | https://helm.releases.hashicorp.com |
+| Chart Name          | consul                              |
+| Release Name        | consul                              |
+| Namespace           | consul                              |
+| Wait                | false                               |
++---------------------+-------------------------------------+
+Set Values: []
+Values File:
+---
+global:
+  # The main enabled/disabled setting.
+  # If true, servers, clients, Consul DNS and the Consul UI will be enabled.
+  # Namespace
+  namespace: consul
+  # The prefix used for all resources created in the Helm chart.
+  name: consul
+  # The name of the datacenter that the agents should register as.
+  datacenter: dc1
+  # Enables TLS across the cluster to verify authenticity of the Consul servers and clients.
+  tls:
+    enabled: true
+  # Enables ACLs across the cluster to secure access to data and APIs.
+  acls:
+  # If true, automatically manage ACL tokens and policies for all Consul components.
+    manageSystemACLs: true
+
+# Configures values that configure the Consul server cluster.
+server:
+  enabled: true
+  # The number of server agents to run. This determines the fault tolerance of the cluster.
+  replicas: 3
+
+  # Contains values that configure the Consul UI.
+
+ui:
+  enabled: true
+  # Registers a Kubernetes Service for the Consul UI as a LoadBalancer.
+  service:
+    type: LoadBalancer
+    annotations: |
+      service.beta.kubernetes.io/aws-load-balancer-type: "external"
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+      service.beta.kubernetes.io/aws-load-balancer-attributes: "load_balancing.cross_zone.enabled=true"
+
+
+# Configures and installs the automatic Consul Connect sidecar injector.
+connectInject:
+  enabled: true
+
+apiGateway:
+  manageExternalCRDs: true
+```

--- a/pkg/application/consul/consul.go
+++ b/pkg/application/consul/consul.go
@@ -22,7 +22,6 @@ func NewApp() *application.Application {
 			ChartName:     "consul",
 			ReleaseName:   "consul",
 			RepositoryURL: "https://helm.releases.hashicorp.com",
-			VersionField:  "1.4.1",
 			ValuesTemplate: &template.TextTemplate{
 				Template: valuesTemplate,
 			},
@@ -39,10 +38,9 @@ const valuesTemplate = `---
 global:
   # The main enabled/disabled setting.
   # If true, servers, clients, Consul DNS and the Consul UI will be enabled.
-  # Namespace
-  namespace: {{ .Namespace }}
+  enabled: true
   # The prefix used for all resources created in the Helm chart.
-  name: {{ .Namespace }}
+  name: null
   # The name of the datacenter that the agents should register as.
   datacenter: {{ .Datacenter }}
   # Enables TLS across the cluster to verify authenticity of the Consul servers and clients.
@@ -74,9 +72,18 @@ ui:
 {{ end }}
 
 # Configures and installs the automatic Consul Connect sidecar injector.
+{{ if .EnableMesh }}
 connectInject:
   enabled: true
-
-apiGateway:
-  manageExternalCRDs: true
+    # Enables Consul on Kubernetes to manage the CRDs used for Gateway API.
+    # Setting this to true will install the CRDs used for the Gateway API when Consul on Kubernetes is installed.
+    # These CRDs can clash with existing Gateway API CRDs if they are already installed in your cluster.
+    # If this setting is false, you will need to install the Gateway API CRDs manually.
+    {{ if .EnableAPIGW }}
+  apiGateway:
+    manageExternalCRDs: true
+  managedGatewayClass:
+    serviceType: LoadBalancer
+    {{ end }}
+{{ end }}
 `

--- a/pkg/application/consul/consul.go
+++ b/pkg/application/consul/consul.go
@@ -1,0 +1,82 @@
+package consul
+
+import (
+	"github.com/awslabs/eksdemo/pkg/application"
+	"github.com/awslabs/eksdemo/pkg/cmd"
+	"github.com/awslabs/eksdemo/pkg/installer"
+	"github.com/awslabs/eksdemo/pkg/template"
+)
+
+// https://developer.hashicorp.com/consul/docs/k8s/installation/install
+// https://developer.hashicorp.com/consul/tutorials/kubernetes/kubernetes-eks-aws
+// https://artifacthub.io/packages/helm/hashicorp/consul
+
+func NewApp() *application.Application {
+	app := &application.Application{
+		Command: cmd.Command{
+			Name:        "consul",
+			Description: "HashiCorp Consul Service-Mesh",
+		},
+
+		Installer: &installer.HelmInstaller{
+			ChartName:     "consul",
+			ReleaseName:   "consul",
+			RepositoryURL: "https://helm.releases.hashicorp.com",
+			VersionField:  "1.4.1",
+			ValuesTemplate: &template.TextTemplate{
+				Template: valuesTemplate,
+			},
+		},
+	}
+
+	app.Options, app.Flags = newOptions()
+
+	return app
+
+}
+
+const valuesTemplate = `---
+global:
+  # The main enabled/disabled setting.
+  # If true, servers, clients, Consul DNS and the Consul UI will be enabled.
+  # Namespace
+  namespace: {{ .Namespace }}
+  # The prefix used for all resources created in the Helm chart.
+  name: {{ .Namespace }}
+  # The name of the datacenter that the agents should register as.
+  datacenter: {{ .Datacenter }}
+  # Enables TLS across the cluster to verify authenticity of the Consul servers and clients.
+  tls:
+    enabled: true
+  # Enables ACLs across the cluster to secure access to data and APIs.
+  acls:
+  # If true, automatically manage ACL tokens and policies for all Consul components.
+    manageSystemACLs: true
+
+# Configures values that configure the Consul server cluster.
+server:
+  enabled: true
+  # The number of server agents to run. This determines the fault tolerance of the cluster.
+  replicas: {{ .Replicas }}
+
+  # Contains values that configure the Consul UI.
+{{ if .EnableUI }}
+ui:
+  enabled: true
+  # Registers a Kubernetes Service for the Consul UI as a LoadBalancer.
+  service:
+    type: LoadBalancer
+    annotations: |
+      service.beta.kubernetes.io/aws-load-balancer-type: "external"
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+      service.beta.kubernetes.io/aws-load-balancer-attributes: "load_balancing.cross_zone.enabled=true"
+{{ end }}
+
+# Configures and installs the automatic Consul Connect sidecar injector.
+connectInject:
+  enabled: true
+
+apiGateway:
+  manageExternalCRDs: true
+`

--- a/pkg/application/consul/options.go
+++ b/pkg/application/consul/options.go
@@ -1,0 +1,49 @@
+package consul
+
+import (
+	"github.com/awslabs/eksdemo/pkg/application"
+	"github.com/awslabs/eksdemo/pkg/cmd"
+)
+
+type ConsulOptions struct {
+	application.ApplicationOptions
+	Namespace  string
+	EnableUI   bool
+	Replicas   int
+	Datacenter string
+}
+
+func newOptions() (options *ConsulOptions, flags cmd.Flags) {
+	options = &ConsulOptions{
+		ApplicationOptions: application.ApplicationOptions{
+			DefaultVersion: &application.LatestPrevious{
+				LatestChart:   "1.4.1",
+				Latest:        "v1.18.1",
+				PreviousChart: "1.4.0",
+				Previous:      "v1.18.0",
+			},
+		},
+		Datacenter: "dc1",
+		Namespace:  "consul",
+		Replicas:   1,
+	}
+
+	flags = cmd.Flags{
+		&cmd.BoolFlag{
+			CommandFlag: cmd.CommandFlag{
+				Name:        "enableUI",
+				Description: "Enable Consul UI",
+			},
+			Option: &options.EnableUI,
+		},
+		&cmd.IntFlag{
+			CommandFlag: cmd.CommandFlag{
+				Name:        "replicas",
+				Description: "1 or 3 replicas",
+			},
+			Option: &options.Replicas,
+		},
+	}
+
+	return
+}

--- a/pkg/application/consul/options.go
+++ b/pkg/application/consul/options.go
@@ -5,16 +5,17 @@ import (
 	"github.com/awslabs/eksdemo/pkg/cmd"
 )
 
-type ConsulOptions struct {
+type AppOptions struct {
 	application.ApplicationOptions
-	Namespace  string
-	EnableUI   bool
-	Replicas   int
-	Datacenter string
+	EnableUI    bool
+	EnableMesh  bool
+	EnableAPIGW bool
+	Replicas    int
+	Datacenter  string
 }
 
-func newOptions() (options *ConsulOptions, flags cmd.Flags) {
-	options = &ConsulOptions{
+func newOptions() (options *AppOptions, flags cmd.Flags) {
+	options = &AppOptions{
 		ApplicationOptions: application.ApplicationOptions{
 			DefaultVersion: &application.LatestPrevious{
 				LatestChart:   "1.4.1",
@@ -22,19 +23,40 @@ func newOptions() (options *ConsulOptions, flags cmd.Flags) {
 				PreviousChart: "1.4.0",
 				Previous:      "v1.18.0",
 			},
+			Namespace: "consul",
 		},
 		Datacenter: "dc1",
-		Namespace:  "consul",
 		Replicas:   1,
 	}
 
 	flags = cmd.Flags{
 		&cmd.BoolFlag{
 			CommandFlag: cmd.CommandFlag{
-				Name:        "enableUI",
+				Name:        "enable-ui",
 				Description: "Enable Consul UI",
 			},
 			Option: &options.EnableUI,
+		},
+		&cmd.BoolFlag{
+			CommandFlag: cmd.CommandFlag{
+				Name:        "enable-mesh",
+				Description: "Enable Consul Service Mesh",
+			},
+			Option: &options.EnableMesh,
+		},
+		&cmd.BoolFlag{
+			CommandFlag: cmd.CommandFlag{
+				Name:        "enable-api-gw",
+				Description: "Enable Consul API Gateway",
+			},
+			Option: &options.EnableAPIGW,
+		},
+		&cmd.StringFlag{
+			CommandFlag: cmd.CommandFlag{
+				Name:        "datacenter",
+				Description: "Specify Consul Datacenter",
+			},
+			Option: &options.Datacenter,
 		},
 		&cmd.IntFlag{
 			CommandFlag: cmd.CommandFlag{


### PR DESCRIPTION
*Issue #161 *

*Description of changes:*
This adds HashiCorp Consul as a base application install, along with some documentation regarding pre-reqs (EBS CSI, and AWS Load Balancer Controller).

Basic Consul installation to start.

Tested in us-east-1 on a 3 node EKS cluster with both 1 replica and 3 replicas successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
