### PR TITLE
fix: delete cluster shouldn't error if Kubeconfig isn't configured

### DIFF
--- a/pkg/application/autoscaling/karpenter/cluster_delete.go
+++ b/pkg/application/autoscaling/karpenter/cluster_delete.go
@@ -22,7 +22,9 @@ import (
 func DeleteCustomResources(kubeContext string) error {
 	client, err := kubernetes.DynamicClient(kubeContext)
 	if err != nil {
-		return fmt.Errorf("failed creating kubernetes dynamic client: %w", err)
+		fmt.Printf("Warning: failed creating kubernetes dynamic client: %s\n", err)
+		fmt.Println("Skipping cleaning up Karpenter resource.")
+		return nil
 	}
 
 	if err := DeleteNodePool(client); err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Deleting a cluster shouldn't error if Kubeconfig isn't configured. Changed to show a warning instead about skipping Karpenter resource cleanup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
