### PR TITLE
add: `create ssm-session` can start a port forwarding session

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,6 +177,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
+	github.com/xtaci/smux v1.5.24 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0 // indirect
 	go.opentelemetry.io/otel v1.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -559,6 +559,8 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
+github.com/xtaci/smux v1.5.24 h1:77emW9dtnOxxOQ5ltR+8BbsX1kzcOxQ5gB+aaV9hXOY=
+github.com/xtaci/smux v1.5.24/go.mod h1:OMlQbT5vcgl2gb49mFkYo6SMf+zP3rcjcwQz7ZU7IGY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/aws/ssm.go
+++ b/pkg/aws/ssm.go
@@ -97,9 +97,15 @@ func (c *SSMClient) GetParameter(name string) (*types.Parameter, error) {
 	return out.Parameter, nil
 }
 
-func (c *SSMClient) StartSession(documentName, target string) (*ssm.StartSessionOutput, error) {
-	return c.Client.StartSession(context.Background(), &ssm.StartSessionInput{
+func (c *SSMClient) StartSession(documentName, target string, params map[string][]string) (*ssm.StartSessionOutput, error) {
+	input := &ssm.StartSessionInput{
 		DocumentName: aws.String(documentName),
 		Target:       aws.String(target),
-	})
+	}
+
+	if len(params) > 0 {
+		input.Parameters = params
+	}
+
+	return c.Client.StartSession(context.Background(), input)
 }

--- a/pkg/cmd/error.go
+++ b/pkg/cmd/error.go
@@ -10,3 +10,12 @@ type ArgumentAndFlagCantBeUsedTogetherError struct {
 func (e *ArgumentAndFlagCantBeUsedTogetherError) Error() string {
 	return fmt.Sprintf("%q argument and %q flag can not be used together", e.Arg, e.Flag)
 }
+
+type FlagRequiresFlagError struct {
+	Flag1 string
+	Flag2 string
+}
+
+func (e *FlagRequiresFlagError) Error() string {
+	return fmt.Sprintf("%q flag requires %q flag", e.Flag1, e.Flag2)
+}

--- a/pkg/resource/ssm/session/options.go
+++ b/pkg/resource/ssm/session/options.go
@@ -3,19 +3,60 @@ package session
 import (
 	"github.com/awslabs/eksdemo/pkg/cmd"
 	"github.com/awslabs/eksdemo/pkg/resource"
+	"github.com/spf13/cobra"
 )
 
 type SessionOptions struct {
 	resource.CommonOptions
+	DocumentName string
 
+	// Create
+	PortForward      int
+	PortForwardLocal int
+
+	// Get
 	History bool
-	State   string
 }
 
-func newOptions() (options *SessionOptions, getFlags cmd.Flags) {
+func newOptions() (options *SessionOptions, createFlags, getFlags cmd.Flags) {
 	options = &SessionOptions{
 		CommonOptions: resource.CommonOptions{
 			ClusterFlagDisabled: true,
+		},
+		DocumentName: "SSM-SessionManagerRunShell",
+	}
+
+	createFlags = cmd.Flags{
+		&cmd.IntFlag{
+			CommandFlag: cmd.CommandFlag{
+				Name:        "local-port",
+				Description: "local port number when creating a port forwarding session",
+				Shorthand:   "L",
+				Validate: func(_ *cobra.Command, _ []string) error {
+					if options.PortForwardLocal != 0 && options.PortForward == 0 {
+						return &cmd.FlagRequiresFlagError{Flag1: "local-port", Flag2: "port-forward"}
+					}
+					if options.PortForwardLocal == 0 {
+						options.PortForwardLocal = options.PortForward
+					}
+					return nil
+				},
+			},
+			Option: &options.PortForwardLocal,
+		},
+		&cmd.IntFlag{
+			CommandFlag: cmd.CommandFlag{
+				Name:        "port-forward",
+				Description: "open a port forwarding session for the given port",
+				Shorthand:   "P",
+				Validate: func(_ *cobra.Command, _ []string) error {
+					if options.PortForward != 0 {
+						options.DocumentName = "AWS-StartPortForwardingSession"
+					}
+					return nil
+				},
+			},
+			Option: &options.PortForward,
 		},
 	}
 

--- a/pkg/resource/ssm/session/ssm_session.go
+++ b/pkg/resource/ssm/session/ssm_session.go
@@ -6,7 +6,9 @@ import (
 )
 
 func NewResource() *resource.Resource {
-	res := &resource.Resource{
+	options, createFlags, getFlags := newOptions()
+
+	return &resource.Resource{
 		Command: cmd.Command{
 			Name:        "ssm-session",
 			Description: "SSM Session",
@@ -14,11 +16,13 @@ func NewResource() *resource.Resource {
 			Args:        []string{"INSTANCE_ID"},
 		},
 
+		CreateFlags: createFlags,
+		GetFlags:    getFlags,
+
 		Getter: &Getter{},
 
 		Manager: &Manager{},
-	}
-	res.Options, res.GetFlags = newOptions()
 
-	return res
+		Options: options,
+	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add: `create ssm-session` can start a port forwarding session

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
