### PR TITLE
add: `get ssm-parameter`

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -50,6 +50,7 @@ import (
 	"github.com/awslabs/eksdemo/pkg/resource/security_group_rule"
 	"github.com/awslabs/eksdemo/pkg/resource/sqs_queue"
 	ssmnode "github.com/awslabs/eksdemo/pkg/resource/ssm/node"
+	"github.com/awslabs/eksdemo/pkg/resource/ssm/parameter"
 	"github.com/awslabs/eksdemo/pkg/resource/ssm/session"
 	"github.com/awslabs/eksdemo/pkg/resource/subnet"
 	"github.com/awslabs/eksdemo/pkg/resource/target_group"
@@ -124,6 +125,7 @@ func NewGetCmd() *cobra.Command {
 	cmd.AddCommand(security_group_rule.NewResource().NewGetCmd())
 	cmd.AddCommand(sqs_queue.NewResource().NewGetCmd())
 	cmd.AddCommand(ssmnode.NewResource().NewGetCmd())
+	cmd.AddCommand(parameter.NewResource().NewGetCmd())
 	cmd.AddCommand(session.NewResource().NewGetCmd())
 	cmd.AddCommand(subnet.NewResource().NewGetCmd())
 	cmd.AddCommand(target_group.NewResource().NewGetCmd())

--- a/pkg/aws/ssm.go
+++ b/pkg/aws/ssm.go
@@ -97,6 +97,29 @@ func (c *SSMClient) GetParameter(name string) (*types.Parameter, error) {
 	return out.Parameter, nil
 }
 
+func (c *SSMClient) GetParametersByPath(path string) ([]types.Parameter, error) {
+	parameters := []types.Parameter{}
+	pageNum := 0
+
+	input := &ssm.GetParametersByPathInput{
+		Path:      aws.String(path),
+		Recursive: aws.Bool(true),
+	}
+
+	paginator := ssm.NewGetParametersByPathPaginator(c.Client, input)
+
+	for paginator.HasMorePages() && pageNum < maxPages {
+		out, err := paginator.NextPage(context.Background())
+		if err != nil {
+			return nil, err
+		}
+		parameters = append(parameters, out.Parameters...)
+		pageNum++
+	}
+
+	return parameters, nil
+}
+
 func (c *SSMClient) StartSession(documentName, target string, params map[string][]string) (*ssm.StartSessionOutput, error) {
 	input := &ssm.StartSessionInput{
 		DocumentName: aws.String(documentName),

--- a/pkg/resource/ssm/parameter/get.go
+++ b/pkg/resource/ssm/parameter/get.go
@@ -1,0 +1,59 @@
+package parameter
+
+import (
+	"errors"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/awslabs/eksdemo/pkg/aws"
+	"github.com/awslabs/eksdemo/pkg/printer"
+	"github.com/awslabs/eksdemo/pkg/resource"
+)
+
+type Getter struct {
+	ssmClient *aws.SSMClient
+}
+
+func NewGetter(ssmClient *aws.SSMClient) *Getter {
+	return &Getter{ssmClient}
+}
+
+func (g *Getter) Init() {
+	if g.ssmClient == nil {
+		g.ssmClient = aws.NewSSMClient()
+	}
+}
+
+func (g *Getter) Get(pathOrName string, output printer.Output, _ resource.Options) error {
+	params, err := g.GetByPathOrName(pathOrName)
+	if err != nil {
+		return err
+	}
+
+	return output.Print(os.Stdout, NewPrinter(params))
+}
+
+func (g *Getter) GetByPathOrName(pathOrName string) ([]types.Parameter, error) {
+	params, err := g.ssmClient.GetParametersByPath(pathOrName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(params) > 0 {
+		return params, nil
+	}
+
+	param, err := g.ssmClient.GetParameter(pathOrName)
+
+	// Return all errors except NotFound
+	var rnfe *types.ParameterNotFound
+	if err != nil && !errors.As(err, &rnfe) {
+		return nil, err
+	}
+
+	if param != nil {
+		return []types.Parameter{*param}, nil
+	}
+
+	return nil, nil
+}

--- a/pkg/resource/ssm/parameter/printer.go
+++ b/pkg/resource/ssm/parameter/printer.go
@@ -1,0 +1,46 @@
+package parameter
+
+import (
+	"io"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/awslabs/eksdemo/pkg/printer"
+	"github.com/hako/durafmt"
+)
+
+type Printer struct {
+	params []types.Parameter
+}
+
+func NewPrinter(params []types.Parameter) *Printer {
+	return &Printer{params}
+}
+
+func (p *Printer) PrintTable(writer io.Writer) error {
+	table := printer.NewTablePrinter()
+	table.SetHeader([]string{"Age", "Name", "Value"})
+
+	for _, p := range p.params {
+		age := durafmt.ParseShort(time.Since(aws.ToTime(p.LastModifiedDate)))
+
+		table.AppendRow([]string{
+			age.String(),
+			aws.ToString(p.Name),
+			aws.ToString(p.Value),
+		})
+	}
+
+	table.Print(writer)
+
+	return nil
+}
+
+func (p *Printer) PrintJSON(writer io.Writer) error {
+	return printer.EncodeJSON(writer, p.params)
+}
+
+func (p *Printer) PrintYAML(writer io.Writer) error {
+	return printer.EncodeYAML(writer, p.params)
+}

--- a/pkg/resource/ssm/parameter/ssm_parameter.go
+++ b/pkg/resource/ssm/parameter/ssm_parameter.go
@@ -1,0 +1,23 @@
+package parameter
+
+import (
+	"github.com/awslabs/eksdemo/pkg/cmd"
+	"github.com/awslabs/eksdemo/pkg/resource"
+)
+
+func NewResource() *resource.Resource {
+	return &resource.Resource{
+		Command: cmd.Command{
+			Name:        "ssm-parameter",
+			Description: "SSM Parameter",
+			Aliases:     []string{"ssm-parameters", "ssm-params", "ssm-param", "params", "param"},
+			Args:        []string{"PATH_OR_NAME"},
+		},
+
+		Getter: &Getter{},
+
+		Options: &resource.CommonOptions{
+			ClusterFlagDisabled: true,
+		},
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add `get ssm-parameter`

Example
```
eksdemo get ssm-param /aws/service/neuron
+--------+--------------------------------------------------------------------------+-----------------------+
|  Age   |                                   Name                                   |         Value         |
+--------+--------------------------------------------------------------------------+-----------------------+
| 2 days | /aws/service/neuron/dlami/base/amazon-linux-2/latest/image_id            | ami-0e2d585f846ff29f6 |
| 2 days | /aws/service/neuron/dlami/base/ubuntu-20.04/latest/image_id              | ami-02aed491b5681c49e |
| 2 days | /aws/service/neuron/dlami/multi-framework/ubuntu-22.04/latest/image_id   | ami-07f9e2ccc9f0f4103 |
| 2 days | /aws/service/neuron/dlami/pytorch-1.13/amazon-linux-2/latest/image_id    | ami-001b12be6fb25e9ae |
| 1 week | /aws/service/neuron/dlami/pytorch-1.13/ubuntu-20.04/latest/image_id      | ami-03a805134c1a6c2e3 |
| 2 days | /aws/service/neuron/dlami/tensorflow-2.10/amazon-linux-2/latest/image_id | ami-04261454d107aa12e |
| 2 days | /aws/service/neuron/dlami/tensorflow-2.10/ubuntu-20.04/latest/image_id   | ami-09af131c9f79d84ab |
+--------+--------------------------------------------------------------------------+-----------------------+
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
