### PR TITLE
refactor: add CreateArgs to cmd.Command

### DIFF
--- a/pkg/cmd/command.go
+++ b/pkg/cmd/command.go
@@ -6,5 +6,6 @@ type Command struct {
 	Description string
 	Aliases     []string
 	Args        []string
+	CreateArgs  []string
 	Hidden      bool
 }

--- a/pkg/resource/ack/amp/logging_configuration.go
+++ b/pkg/resource/ack/amp/logging_configuration.go
@@ -24,7 +24,7 @@ func NewLoggingConfigurationResource() *resource.Resource {
 			Name:        "amp-logging-configuration",
 			Description: "AMP Logging Configuration",
 			Aliases:     []string{"amp-logging-config", "amp-logging", "amp-log"},
-			Args:        []string{"NAME"},
+			CreateArgs:  []string{"NAME"},
 		},
 
 		Manager: &manifest.ResourceManager{

--- a/pkg/resource/ack/amp/workspace.go
+++ b/pkg/resource/ack/amp/workspace.go
@@ -22,7 +22,7 @@ func NewWorkspaceResource() *resource.Resource {
 			Name:        "amp-workspace",
 			Description: "AMP Workspace",
 			Aliases:     []string{"amp"},
-			Args:        []string{"ALIAS"},
+			CreateArgs:  []string{"ALIAS"},
 		},
 
 		Manager: &manifest.ResourceManager{

--- a/pkg/resource/ack/ec2/security_group.go
+++ b/pkg/resource/ack/ec2/security_group.go
@@ -18,7 +18,7 @@ func NewSecurityGroupResource() *resource.Resource {
 			Name:        "security-group",
 			Description: "EC2 Security Group",
 			Aliases:     []string{"security-groups", "sg"},
-			Args:        []string{"NAME"},
+			CreateArgs:  []string{"NAME"},
 		},
 
 		Manager: &manifest.ResourceManager{

--- a/pkg/resource/ack/ec2/subnet.go
+++ b/pkg/resource/ack/ec2/subnet.go
@@ -20,7 +20,7 @@ func NewSubnetResource() *resource.Resource {
 			Name:        "subnet",
 			Description: "EC2 Subnet",
 			Aliases:     []string{"subnets"},
-			Args:        []string{"NAME"},
+			CreateArgs:  []string{"NAME"},
 		},
 
 		Manager: &manifest.ResourceManager{

--- a/pkg/resource/ack/ec2/vpc.go
+++ b/pkg/resource/ack/ec2/vpc.go
@@ -18,7 +18,7 @@ func NewVpcResource() *resource.Resource {
 			Name:        "vpc",
 			Description: "Virtual Private Cloud (VPC)",
 			Aliases:     []string{"vpcs"},
-			Args:        []string{"NAME"},
+			CreateArgs:  []string{"NAME"},
 		},
 
 		Manager: &manifest.ResourceManager{

--- a/pkg/resource/ack/ecr/ecr.go
+++ b/pkg/resource/ack/ecr/ecr.go
@@ -19,7 +19,7 @@ func NewResource() *resource.Resource {
 			Name:        "ecr-repo",
 			Description: "ECR Repository",
 			Aliases:     []string{"ecr"},
-			Args:        []string{"NAME"},
+			CreateArgs:  []string{"NAME"},
 		},
 
 		Manager: &manifest.ResourceManager{

--- a/pkg/resource/ack/eks/fargate.go
+++ b/pkg/resource/ack/eks/fargate.go
@@ -24,7 +24,7 @@ func NewFargateProfileResource() *resource.Resource {
 			Name:        "eks-fargate-profile",
 			Description: "Fargate Profile",
 			Aliases:     []string{"eks-fargate", "fargate-profile", "fargate", "fp"},
-			Args:        []string{"NAME"},
+			CreateArgs:  []string{"NAME"},
 		},
 
 		Manager: &manifest.ResourceManager{

--- a/pkg/resource/ack/iam/role.go
+++ b/pkg/resource/ack/iam/role.go
@@ -18,7 +18,7 @@ func NewRoleResource() *resource.Resource {
 			Name:        "iam-role",
 			Description: "ECR Repository",
 			Aliases:     []string{"role"},
-			Args:        []string{"NAME"},
+			CreateArgs:  []string{"NAME"},
 		},
 
 		Manager: &manifest.ResourceManager{

--- a/pkg/resource/ack/s3/s3.go
+++ b/pkg/resource/ack/s3/s3.go
@@ -13,7 +13,7 @@ func NewResource() *resource.Resource {
 			Name:        "s3-bucket",
 			Description: "Amazon S3 bucket",
 			Aliases:     []string{"s3"},
-			Args:        []string{"NAME"},
+			CreateArgs:  []string{"NAME"},
 		},
 
 		Manager: &manifest.ResourceManager{

--- a/pkg/resource/acm_certificate/certificate.go
+++ b/pkg/resource/acm_certificate/certificate.go
@@ -11,6 +11,7 @@ func NewResource() *resource.Resource {
 			Name:        "acm-certificate",
 			Description: "ACM Cerificate",
 			Aliases:     []string{"acm-certificates", "acm-certs", "acm-cert", "acm"},
+			CreateArgs:  []string{"NAME"},
 			Args:        []string{"NAME"},
 		},
 

--- a/pkg/resource/addon/addon.go
+++ b/pkg/resource/addon/addon.go
@@ -13,6 +13,7 @@ func NewResource() *resource.Resource {
 			Name:        "addon",
 			Description: "EKS Managed Addon",
 			Aliases:     []string{"addons"},
+			CreateArgs:  []string{"NAME"},
 			Args:        []string{"NAME"},
 		},
 

--- a/pkg/resource/amg_workspace/amg_workspace.go
+++ b/pkg/resource/amg_workspace/amg_workspace.go
@@ -22,6 +22,7 @@ func NewResourceWithOptions(options *AmgOptions) *resource.Resource {
 			Name:        "amg-workspace",
 			Description: "Amazon Managed Grafana Workspace",
 			Aliases:     []string{"amg"},
+			CreateArgs:  []string{"NAME"},
 			Args:        []string{"NAME"},
 		},
 

--- a/pkg/resource/amp_workspace/amp_workspace.go
+++ b/pkg/resource/amp_workspace/amp_workspace.go
@@ -19,6 +19,7 @@ func NewResourceWithOptions(options *AmpWorkspaceOptions) *resource.Resource {
 			Name:        "amp-workspace",
 			Description: "Amazon Managed Prometheus Workspace",
 			Aliases:     []string{"amp"},
+			CreateArgs:  []string{"ALIAS"},
 			Args:        []string{"ALIAS"},
 		},
 

--- a/pkg/resource/cluster/cluster.go
+++ b/pkg/resource/cluster/cluster.go
@@ -14,6 +14,7 @@ func NewResource() *resource.Resource {
 			Name:        "cluster",
 			Description: "EKS Cluster",
 			Aliases:     []string{"clusters"},
+			CreateArgs:  []string{"NAME"},
 			Args:        []string{"NAME"},
 		},
 

--- a/pkg/resource/cognito/client/app_client.go
+++ b/pkg/resource/cognito/client/app_client.go
@@ -20,8 +20,9 @@ func NewWithOptions(options *Options) *resource.Resource {
 		Command: cmd.Command{
 			Name:        "app-client",
 			Description: "Cognito User Pool App Client",
-			Args:        []string{"NAME"},
 			Aliases:     []string{"client"},
+			CreateArgs:  []string{"NAME"},
+			Args:        []string{"NAME"},
 		},
 
 		Getter: &Getter{},

--- a/pkg/resource/cognito/domain/cognito_domain.go
+++ b/pkg/resource/cognito/domain/cognito_domain.go
@@ -20,6 +20,7 @@ func NewWithOptions(options *Options) *resource.Resource {
 		Command: cmd.Command{
 			Name:        "domain",
 			Description: "Cognito User Pool Domain",
+			CreateArgs:  []string{"NAME"},
 			Args:        []string{"DOMAIN"},
 		},
 

--- a/pkg/resource/cognito/userpool/cognito_userpool.go
+++ b/pkg/resource/cognito/userpool/cognito_userpool.go
@@ -20,6 +20,7 @@ func NewWithOptions(options *Options) *resource.Resource {
 			Name:        "user-pool",
 			Description: "Cognito User Pool",
 			Aliases:     []string{"user-pools", "userpools", "userpool", "up"},
+			CreateArgs:  []string{"NAME"},
 			Args:        []string{"NAME"},
 		},
 

--- a/pkg/resource/dns_record/dns_record.go
+++ b/pkg/resource/dns_record/dns_record.go
@@ -6,20 +6,25 @@ import (
 )
 
 func NewResource() *resource.Resource {
-	res := &resource.Resource{
+	options, createFlags, deleteFlags, getFlags := newOptions()
+
+	return &resource.Resource{
 		Command: cmd.Command{
 			Name:        "dns-record",
 			Description: "Route53 Resource Record Set",
 			Aliases:     []string{"dns-records", "records", "record", "dns"},
+			CreateArgs:  []string{"NAME"},
 			Args:        []string{"NAME"},
 		},
+
+		CreateFlags: createFlags,
+		DeleteFlags: deleteFlags,
+		GetFlags:    getFlags,
 
 		Getter: &Getter{},
 
 		Manager: &Manager{},
+
+		Options: options,
 	}
-
-	res.Options, res.CreateFlags, res.DeleteFlags, res.GetFlags = newOptions()
-
-	return res
 }

--- a/pkg/resource/fargate_profile/fargate_profile.go
+++ b/pkg/resource/fargate_profile/fargate_profile.go
@@ -8,13 +8,18 @@ import (
 )
 
 func NewResource() *resource.Resource {
-	res := &resource.Resource{
+	options, createFlags := NewOptions()
+
+	return &resource.Resource{
 		Command: cmd.Command{
 			Name:        "fargate-profile",
 			Description: "EKS Fargate Profile",
 			Aliases:     []string{"fargate-profiles", "fargateprofiles", "fargateprofile", "fargate", "fp"},
+			CreateArgs:  []string{"NAME"},
 			Args:        []string{"NAME"},
 		},
+
+		CreateFlags: createFlags,
 
 		Getter: &Getter{},
 
@@ -27,11 +32,9 @@ func NewResource() *resource.Resource {
 				Template: deleteCommandTemplate,
 			},
 		},
+
+		Options: options,
 	}
-
-	res.Options, res.CreateFlags = NewOptions()
-
-	return res
 }
 
 const eksctlTemplate = `

--- a/pkg/resource/log_group/log_group.go
+++ b/pkg/resource/log_group/log_group.go
@@ -6,20 +6,24 @@ import (
 )
 
 func NewResource() *resource.Resource {
-	res := &resource.Resource{
+	options, deleteFlags, getFlags := newOptions()
+
+	return &resource.Resource{
 		Command: cmd.Command{
 			Name:        "log-group",
 			Description: "CloudWatch Log Group",
 			Aliases:     []string{"log-groups", "loggroup", "lg"},
+			CreateArgs:  []string{"NAME"},
 			Args:        []string{"NAME"},
 		},
+
+		DeleteFlags: deleteFlags,
+		GetFlags:    getFlags,
 
 		Getter: &Getter{},
 
 		Manager: &Manager{},
+
+		Options: options,
 	}
-
-	res.Options, res.GetFlags, res.DeleteFlags = newOptions()
-
-	return res
 }

--- a/pkg/resource/log_group/options.go
+++ b/pkg/resource/log_group/options.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newOptions() (options *resource.CommonOptions, getFlags, deleteFlags cmd.Flags) {
+func newOptions() (options *resource.CommonOptions, deleteFlags, getFlags cmd.Flags) {
 	options = &resource.CommonOptions{
 		DeleteArgumentOptional: true,
 		ClusterFlagDisabled:    true,

--- a/pkg/resource/nodegroup/nodegroup.go
+++ b/pkg/resource/nodegroup/nodegroup.go
@@ -13,6 +13,7 @@ func NewResource() *resource.Resource {
 			Name:        "nodegroup",
 			Description: "EKS Managed Nodegroup",
 			Aliases:     []string{"nodegroups", "mng", "ng"},
+			CreateArgs:  []string{"NAME"},
 			Args:        []string{"NAME"},
 		},
 

--- a/pkg/resource/nodegroup/spot.go
+++ b/pkg/resource/nodegroup/spot.go
@@ -13,7 +13,7 @@ func NewSpotResource() *resource.Resource {
 			Name:        "nodegroup-spot",
 			Description: "Managed Nodegroup with Spot Instances",
 			Aliases:     []string{"spot", "ngspot", "ng-spot"},
-			Args:        []string{"NAME"},
+			CreateArgs:  []string{"NAME"},
 		},
 
 		Manager: &eksctl.ResourceManager{

--- a/pkg/resource/options.go
+++ b/pkg/resource/options.go
@@ -23,7 +23,9 @@ type Options interface {
 }
 
 type CommonOptions struct {
-	Name                   string
+	Name string
+	// If both ClusterFlagDisabled and ClusterFlagOptional are true, the cluster flag
+	// is only available for Get, and not available for Create, Update and Delete commands
 	ClusterFlagDisabled    bool
 	ClusterFlagOptional    bool
 	DeleteArgumentOptional bool

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -39,8 +39,8 @@ func (r *Resource) Update(cmd *cobra.Command) error {
 
 func (r *Resource) NewCreateCmd() *cobra.Command {
 	use := r.Command.Name
-	if len(r.Args) > 0 {
-		use += " " + strings.Join(r.Args, " ")
+	if len(r.CreateArgs) > 0 {
+		use += " " + strings.Join(r.CreateArgs, " ")
 	}
 
 	cmd := &cobra.Command{
@@ -48,7 +48,7 @@ func (r *Resource) NewCreateCmd() *cobra.Command {
 		Short:   r.Description,
 		Long:    "Create " + r.Description,
 		Aliases: r.Aliases,
-		Args:    cobra.ExactArgs(len(r.Args)),
+		Args:    cobra.ExactArgs(len(r.CreateArgs)),
 		Hidden:  r.Hidden,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := r.CreateFlags.ValidateFlags(cmd, args); err != nil {
@@ -60,7 +60,7 @@ func (r *Resource) NewCreateCmd() *cobra.Command {
 			}
 			cmd.SilenceUsage = true
 
-			if len(r.Args) > 0 {
+			if len(r.CreateArgs) > 0 {
 				r.SetName(args[0])
 			}
 

--- a/pkg/resource/ssm/session/ssm_session.go
+++ b/pkg/resource/ssm/session/ssm_session.go
@@ -13,7 +13,8 @@ func NewResource() *resource.Resource {
 			Name:        "ssm-session",
 			Description: "SSM Session",
 			Aliases:     []string{"session"},
-			Args:        []string{"INSTANCE_ID"},
+			CreateArgs:  []string{"INSTANCE_ID"},
+			Args:        []string{"SESSION_ID"},
 		},
 
 		CreateFlags: createFlags,

--- a/pkg/resource/target_group/target_group.go
+++ b/pkg/resource/target_group/target_group.go
@@ -11,6 +11,7 @@ func NewResource() *resource.Resource {
 			Name:        "target-group",
 			Description: "Target Group",
 			Aliases:     []string{"target-groups", "tg"},
+			CreateArgs:  []string{"NAME"},
 			Args:        []string{"NAME"},
 		},
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add `CreateArgs` to cmd.Command

Initially it was assumed the arguments to Create, Get, Update and Delete would have the same arguments. But that won't always be the case. For instance, you get EC2 instances by ID, but you don't pass the ID as an argument when creating an EC2 instance.

This allows for different arguments depending on the command. Eventually will break out GetArgs and DeleteArgs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
