### PR TITLE
Wrong condition in template for AmazonLinux2023

### DIFF
--- a/pkg/resource/nodegroup/nodegroup.go
+++ b/pkg/resource/nodegroup/nodegroup.go
@@ -39,7 +39,7 @@ func NewResource() *resource.Resource {
 const EksctlTemplate = `
 managedNodeGroups:
 - name: {{ .NodegroupName }}
-{{- if and .AMI (ne .OperatingSystem "AmazonLinux2023") }}
+{{- if .AMI }}
   ami: {{ .AMI }}
 {{- end }}
   amiFamily: {{ .OperatingSystem }}
@@ -58,7 +58,7 @@ managedNodeGroups:
 {{- end }}
   minSize: {{ .MinSize }}
   maxSize: {{ .MaxSize }}
-{{- if .AMI }}
+{{- if and .AMI (ne .OperatingSystem "AmazonLinux2023") }}
   overrideBootstrapCommand: |
     #!/bin/bash
     /etc/eks/bootstrap.sh {{ .ClusterName }}


### PR DESCRIPTION
Made a mistake in the previous PR:
- https://github.com/awslabs/eksdemo/pull/171/files#diff-0a673a70f196ec6b6681f6852f6c4ee63bb62a27054dbb077bfba71e9f7c1f47R41

Should instead be around `overrideBootstrapCommand` 
- https://github.com/awslabs/eksdemo/pull/171/files#diff-0a673a70f196ec6b6681f6852f6c4ee63bb62a27054dbb077bfba71e9f7c1f47L60