### PR TITLE
fix: Karpenter 1.0 installation fails when using Bottlerocket

### DIFF
--- a/pkg/application/karpenter/options.go
+++ b/pkg/application/karpenter/options.go
@@ -83,7 +83,18 @@ func newOptions() (options *KarpenterOptions, flags cmd.Flags) {
 					}
 					if strings.EqualFold(options.AMIFamily, "Bottlerocket") {
 						options.AMIFamily = "Bottlerocket"
-						return nil
+
+						bottlerocketAMI, err := ssm.GetBottlerocketAMI(eksVersion)
+						if err != nil {
+							return err
+						}
+
+						bottlerocketArm64AMI, err := ssm.GetBottlerocketArm64AMI(eksVersion)
+						if err != nil {
+							return err
+						}
+
+						options.AMISelectorIDs = append(options.AMISelectorIDs, bottlerocketAMI, bottlerocketArm64AMI)
 					}
 					return nil
 				},

--- a/pkg/resource/ssm/parameter/ami_lookup.go
+++ b/pkg/resource/ssm/parameter/ami_lookup.go
@@ -18,6 +18,12 @@ const eksAL2023AMI = "/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64
 // /aws/service/eks/optimized-ami/<eks-version>/amazon-linux-2023/arm64/standard/recommended/image_id
 const eksAL2023Arm64AMI = "/aws/service/eks/optimized-ami/%s/amazon-linux-2023/arm64/standard/recommended/image_id"
 
+// /aws/service/bottlerocket/aws-k8s-<eks-version>/x86_64/latest/image_id
+const bottlerocketAMI = "/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_id"
+
+// /aws/service/bottlerocket/aws-k8s-<eks-version>/arm64/latest/image_id
+const bottlerocketArm64AMI = "/aws/service/bottlerocket/aws-k8s-%s/arm64/latest/image_id"
+
 func (g *Getter) GetEKSOptimizedAL2AMI(eksVersion string) (string, error) {
 	return g.getEKSOptimizedAMI(eksAL2AMI, eksVersion)
 }
@@ -32,6 +38,14 @@ func (g *Getter) GetEKSOptimizedAL2023AMI(eksVersion string) (string, error) {
 
 func (g *Getter) GetEKSOptimizedAL2023Arm64AMI(eksVersion string) (string, error) {
 	return g.getEKSOptimizedAMI(eksAL2023Arm64AMI, eksVersion)
+}
+
+func (g *Getter) GetBottlerocketAMI(eksVersion string) (string, error) {
+	return g.getEKSOptimizedAMI(bottlerocketAMI, eksVersion)
+}
+
+func (g *Getter) GetBottlerocketArm64AMI(eksVersion string) (string, error) {
+	return g.getEKSOptimizedAMI(bottlerocketArm64AMI, eksVersion)
 }
 
 func (g *Getter) getEKSOptimizedAMI(paramName, eksVersion string) (string, error) {

--- a/pkg/resource/ssm/parameter/ami_lookup.go
+++ b/pkg/resource/ssm/parameter/ami_lookup.go
@@ -19,22 +19,22 @@ const eksAL2023AMI = "/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64
 const eksAL2023Arm64AMI = "/aws/service/eks/optimized-ami/%s/amazon-linux-2023/arm64/standard/recommended/image_id"
 
 func (g *Getter) GetEKSOptimizedAL2AMI(eksVersion string) (string, error) {
-	return g.getEKSOptmizedAMI(eksAL2AMI, eksVersion)
+	return g.getEKSOptimizedAMI(eksAL2AMI, eksVersion)
 }
 
 func (g *Getter) GetEKSOptimizedAL2Arm64AMI(eksVersion string) (string, error) {
-	return g.getEKSOptmizedAMI(eksAL2Arm64AMI, eksVersion)
+	return g.getEKSOptimizedAMI(eksAL2Arm64AMI, eksVersion)
 }
 
 func (g *Getter) GetEKSOptimizedAL2023AMI(eksVersion string) (string, error) {
-	return g.getEKSOptmizedAMI(eksAL2023AMI, eksVersion)
+	return g.getEKSOptimizedAMI(eksAL2023AMI, eksVersion)
 }
 
 func (g *Getter) GetEKSOptimizedAL2023Arm64AMI(eksVersion string) (string, error) {
-	return g.getEKSOptmizedAMI(eksAL2023Arm64AMI, eksVersion)
+	return g.getEKSOptimizedAMI(eksAL2023Arm64AMI, eksVersion)
 }
 
-func (g *Getter) getEKSOptmizedAMI(paramName, eksVersion string) (string, error) {
+func (g *Getter) getEKSOptimizedAMI(paramName, eksVersion string) (string, error) {
 	param, err := g.ssmClient.GetParameter(fmt.Sprintf(paramName, eksVersion))
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Issue #249 

*Description of changes:*
Adds lookups for Bottlerocket AMIs so that the EC2NodeClass is created correctly.

```
$ ./eksdemo install karpenter -c main-lab -a Bottlerocket --dry-run

apiVersion: karpenter.k8s.aws/v1
kind: EC2NodeClass
metadata:
  name: default
spec:
  amiFamily: Bottlerocket
  role: KarpenterNodeRole-main-lab
  subnetSelectorTerms:
    - tags:
        Name: eksctl-main-lab-cluster/SubnetPrivate*
  securityGroupSelectorTerms:
    - tags:
        aws:eks:cluster-name: main-lab
  tags:
    eksdemo.io/version: v0.16.0-29-g43b91f2-dev
  amiSelectorTerms:
    - id: ami-09a54b713b931a469
    - id: ami-0b07fdee374ab4cf3
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
