### PR TITLE
fix: `aws-lb-controller` permissions

### DIFF
--- a/pkg/application/aws/lbc/aws_lb_controller.go
+++ b/pkg/application/aws/lbc/aws_lb_controller.go
@@ -89,6 +89,7 @@ Statement:
   - elasticloadbalancing:DescribeTargetHealth
   - elasticloadbalancing:DescribeTags
   - elasticloadbalancing:DescribeTrustStores
+  - elasticloadbalancing:DescribeListenerAttributes
   Resource: "*"
 - Effect: Allow
   Action:
@@ -192,6 +193,7 @@ Statement:
   - elasticloadbalancing:ModifyTargetGroup
   - elasticloadbalancing:ModifyTargetGroupAttributes
   - elasticloadbalancing:DeleteTargetGroup
+  - elasticloadbalancing:ModifyListenerAttributes
   Resource: "*"
   Condition:
     'Null':


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix `aws-lb-controller` permissions.

New IAM permissions were required with the upgrade to v2.9.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
