### PR TITLE
Add support for EKS/K8S 1.32

### DIFF
--- a/pkg/application/autoscaling/cluster_autoscaler/cluster_autoscaler.go
+++ b/pkg/application/autoscaling/cluster_autoscaler/cluster_autoscaler.go
@@ -13,7 +13,7 @@ import (
 // GitHub:  https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws
 // Helm:    https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler
 // Repo:    registry.k8s.io/autoscaling/cluster-autoscaler
-// Version: Latest for k8s 1.31 is v1.31.0 (as of 9/30/24)
+// Version: Latest for k8s 1.32 is v1.32.0 (as of 9/30/24)
 
 func NewApp() *application.Application {
 	app := &application.Application{
@@ -40,8 +40,9 @@ func NewApp() *application.Application {
 			Namespace:      "kube-system",
 			ServiceAccount: "cluster-autoscaler",
 			DefaultVersion: &application.KubernetesVersionDependent{
-				LatestChart: "9.42.0",
+				LatestChart: "9.46.0",
 				Latest: map[string]string{
+					"1.32": "v1.32.0",
 					"1.31": "v1.31.0",
 					"1.30": "v1.30.2",
 					"1.29": "v1.29.4",
@@ -51,7 +52,7 @@ func NewApp() *application.Application {
 					"1.25": "v1.25.3",
 					"1.24": "v1.24.3",
 				},
-				PreviousChart: "9.37.0",
+				PreviousChart: "9.42.0",
 				Previous: map[string]string{
 					"1.31": "v1.31.0",
 					"1.30": "v1.30.1",

--- a/pkg/eksctl/eksctl.go
+++ b/pkg/eksctl/eksctl.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-const minVersion = "0.191.0"
+const minVersion = "0.203.0"
 
 func GetClusterName(cluster string) string {
 	return fmt.Sprintf("%s.%s.eksctl.io", cluster, aws.Region())

--- a/pkg/resource/cluster/options.go
+++ b/pkg/resource/cluster/options.go
@@ -53,7 +53,7 @@ func addOptions(res *resource.Resource) *resource.Resource {
 	options := &ClusterOptions{
 		CommonOptions: resource.CommonOptions{
 			ClusterFlagDisabled: true,
-			KubernetesVersion:   "1.31",
+			KubernetesVersion:   "1.32",
 		},
 
 		HostnameType:     string(types.HostnameTypeResourceName),
@@ -86,7 +86,7 @@ func addOptions(res *resource.Resource) *resource.Resource {
 				Description: "Kubernetes version",
 				Shorthand:   "v",
 			},
-			Choices: []string{"1.31", "1.30", "1.29", "1.28", "1.27", "1.26", "1.25", "1.24"},
+			Choices: []string{"1.32", "1.31", "1.30", "1.29", "1.28", "1.27", "1.26", "1.25", "1.24"},
 			Option:  &options.KubernetesVersion,
 		},
 		&cmd.BoolFlag{


### PR DESCRIPTION
- Add 1.32 to list of allowed versions (and as default)
- Update to latest eksctl to be required
- Bump cluster-autoscaler chart as well to support 1.32

Similar to what was filed for 1.31 in https://github.com/awslabs/eksdemo/pull/252