### PR TITLE
Add support for specifying volume type/size for node groups

### DIFF
--- a/pkg/resource/nodegroup/nodegroup.go
+++ b/pkg/resource/nodegroup/nodegroup.go
@@ -58,6 +58,11 @@ managedNodeGroups:
 {{- end }}
   minSize: {{ .MinSize }}
   maxSize: {{ .MaxSize }}
+  volumeSize: {{ .VolumeSize }}
+  volumeType: {{ .VolumeType }}
+{{- if eq .VolumeType "io2" }}
+  volumeIOPS: 16000
+{{- end }}
 {{- if and .AMI (ne .OperatingSystem "AmazonLinux2023") }}
   overrideBootstrapCommand: |
     #!/bin/bash

--- a/pkg/resource/nodegroup/options.go
+++ b/pkg/resource/nodegroup/options.go
@@ -43,6 +43,8 @@ type NodegroupOptions struct {
 	SpotvCPUs        int
 	SpotMemory       int
 	Taints           []Taint
+	VolumeSize       int
+	VolumeType       string
 
 	UpdateDesired int
 	UpdateMin     int
@@ -65,6 +67,8 @@ func NewOptions() (options *NodegroupOptions, createFlags, updateFlags cmd.Flags
 		OperatingSystem: "AmazonLinux2",
 		SpotvCPUs:       2,
 		SpotMemory:      4,
+		VolumeSize:      80,
+		VolumeType:      "gp3",
 	}
 
 	createFlags = cmd.Flags{
@@ -99,6 +103,20 @@ func NewOptions() (options *NodegroupOptions, createFlags, updateFlags cmd.Flags
 				},
 			},
 			Option: &options.MinSize,
+		},
+		&cmd.IntFlag{
+			CommandFlag: cmd.CommandFlag{
+				Name:        "volume-size",
+				Description: "volume size in GiB",
+			},
+			Option: &options.VolumeSize,
+		},
+		&cmd.StringFlag{
+			CommandFlag: cmd.CommandFlag{
+				Name:        "volume-type",
+				Description: "volume type (one of gp2/gp3/io1/io2/sc1/st1 etc)",
+			},
+			Option: &options.VolumeType,
 		},
 		&cmd.IntFlag{
 			CommandFlag: cmd.CommandFlag{


### PR DESCRIPTION
defaults are 80 GB with gp3 as before, but folks can use the following with this PR:
```
--volume-size 2048 --volume-type io2
```

Note: for `io2` specifically, we need to specify `volumeIOPS` as well, so hardcoded it for now. we can parameterize it later if more folks start needing to tune it.