### PR TITLE
Add more command line params - timeout and volume-iops

### DIFF
--- a/pkg/resource/cluster/cluster.go
+++ b/pkg/resource/cluster/cluster.go
@@ -9,6 +9,13 @@ import (
 )
 
 func NewResource() *resource.Resource {
+	resManager := &eksctl.ResourceManager{
+		Resource: "cluster",
+		ConfigTemplate: &template.TextTemplate{
+			Template: eksctl.EksctlHeader + EksctlTemplate + nodegroup.EksctlTemplate,
+		},
+		DeleteFlags: []string{"--disable-nodegroup-eviction"},
+	}
 	res := &resource.Resource{
 		Command: cmd.Command{
 			Name:        "cluster",
@@ -17,19 +24,11 @@ func NewResource() *resource.Resource {
 			CreateArgs:  []string{"NAME"},
 			Args:        []string{"NAME"},
 		},
-
-		Getter: &Getter{},
-
-		Manager: &eksctl.ResourceManager{
-			Resource: "cluster",
-			ConfigTemplate: &template.TextTemplate{
-				Template: eksctl.EksctlHeader + EksctlTemplate + nodegroup.EksctlTemplate,
-			},
-			DeleteFlags: []string{"--disable-nodegroup-eviction"},
-		},
+		Getter:  &Getter{},
+		Manager: resManager,
 	}
 
-	return addOptions(res)
+	return addOptions(res, resManager)
 }
 
 const EksctlTemplate = `

--- a/pkg/resource/nodegroup/options.go
+++ b/pkg/resource/nodegroup/options.go
@@ -47,6 +47,7 @@ type NodegroupOptions struct {
 	SpotvCPUs        int
 	SpotMemory       int
 	Taints           []Taint
+	VolumeIOPS       int
 	VolumeSize       int
 	VolumeType       string
 
@@ -121,6 +122,21 @@ func NewOptions() (options *NodegroupOptions, createFlags, updateFlags cmd.Flags
 				Description: "volume type (one of gp2/gp3/io1/io2/sc1/st1 etc)",
 			},
 			Option: &options.VolumeType,
+		},
+		&cmd.IntFlag{
+			CommandFlag: cmd.CommandFlag{
+				Name:        "volume-iops",
+				Description: "IOPS for io1/io2 volumes",
+				Validate: func(_ *cobra.Command, _ []string) error {
+					if options.VolumeType == "io1" || options.VolumeType == "io2" {
+						if options.VolumeIOPS < 100 || options.VolumeIOPS > 64000 {
+							return fmt.Errorf("IOPS must be between 100 and 64000")
+						}
+					}
+					return nil
+				},
+			},
+			Option: &options.VolumeIOPS,
 		},
 		&cmd.IntFlag{
 			CommandFlag: cmd.CommandFlag{


### PR DESCRIPTION
- eksctl was defaulting to 25 minutes, let's allow a command line param so folks can bump it as needed
- just setting volume type was not enough with the hard-coded 16k iops, making it configurable.